### PR TITLE
Make github link clickable

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -46,3 +46,8 @@ canvas {
   padding: 1em 2em;
   font-size: 0.8em;
 }
+
+.advices-count a {
+  position: relative;
+  z-index: 6;
+}


### PR DESCRIPTION
The github link was hiding behind the canvas; just push it to the front.
